### PR TITLE
Added new loader without model nor clip input. Added list output with…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,17 @@
 I'm talking about these words right there:
 
 ![image](https://github.com/Extraltodeus/LoadLoraWithTags/assets/15731540/f4685bd4-5575-4055-a589-89e77eee1365)
+
+
+# LoraTagsQueryOnly
+- Same as LoadLoraWithTags but without the need of inputing a model and a clip
+
+# TagsSelector
+- Allow to chose which tags to select.
+- Can use ranges `5:8`
+- Can select individal indexes `2,3,9`
+- Can mix both `2,3,1:5,9`
+- Can use negative values like in a python list to start from the end `2, -5:`
+
+# TagsViewer
+- Helper to show the available tag and their indexes

--- a/load_lora_with_tags.py
+++ b/load_lora_with_tags.py
@@ -45,10 +45,9 @@ def calculate_sha256(file_path):
 def load_and_save_tags(lora_name, print_tags, query_tags, force_fetch):
     json_tags_path = "./loras_tags.json"
     lora_tags = load_json_from_file(json_tags_path)
-    output_tags = lora_tags.get(lora_name, None) if lora_tags is not None else None
-    if output_tags is not None:
-        output_tags_list = output_tags
-        output_tags = ", ".join(output_tags)
+    output_tags_list = lora_tags.get(lora_name, None) if lora_tags is not None else None
+    if output_tags_list is not None:
+        output_tags = ", ".join(output_tags_list)
         if print_tags:
                 print("trainedWords:",output_tags)
     else:
@@ -69,6 +68,7 @@ def load_and_save_tags(lora_name, print_tags, query_tags, force_fetch):
                 lora_tags[lora_name] = model_info["trainedWords"]
                 save_dict_to_json(lora_tags,json_tags_path)
                 output_tags = ", ".join(model_info["trainedWords"])
+                output_tags_list = model_info["trainedWords"]
                 if print_tags:
                     print("trainedWords:",output_tags)
         else:
@@ -105,6 +105,7 @@ class LoraLoaderTagsQuery:
                 }
     
     RETURN_TYPES = ("MODEL", "CLIP", "STRING", "LIST",)
+    RETURN_NAMES = ("MODEL", "CLIP", "civitai_tags", "civitai_tags_list")
     FUNCTION = "load_lora"
     CATEGORY = "llwt"
 
@@ -164,6 +165,7 @@ class LoraTagsQueryOnly:
         }
     
     RETURN_TYPES = ("STRING", "LIST",)
+    RETURN_NAMES = ("civitai_tags", "civitai_tags_list")
     FUNCTION = "load_lora"
     CATEGORY = "llwt"
 


### PR DESCRIPTION
Hello, I love your custom node. I wanted to add more flexibility to it. Some of it might be out of scope.

First I added a new version of the loader without the clip and model input.
![image](https://github.com/Extraltodeus/LoadLoraWithTags/assets/17302538/ebc7c3f0-c0ed-4784-aaeb-5ec32519d43b)
Since I use Efficient Loader I don't need to load another clip / checkpoint. And if I do so using the Efficient Loader output, I create a loop in the graph node and trigger an error.
The second thing I added is a way to filter the tags. Especially because sometimes some tags are redundant and break the whole generation.
![image](https://github.com/Extraltodeus/LoadLoraWithTags/assets/17302538/d8fd2431-1de6-45d1-8c7f-4d02763a9eba)
The format is simple. It's the same as python list index, but can select multiple index or ranges of indexes separated by comas.  
Ex: `0, 3, 5:8, -8:`

I also added a way to visualize more easily the available tags.  

And finally since this project contains now 4 nodes I decided to create a new category llwt to group them all.  

Should look like this :  
![image](https://github.com/Extraltodeus/LoadLoraWithTags/assets/17302538/05658b7e-a52f-4416-b9cb-7c2d3faa62fc)

Change summary:
- Lora tag loader without model / clip input
- New output `list` containing the raw tag list (+ `opt_prompt` in the last index)
- A new node to select the tags from the list.
- A new node to convert the list output as a string in the format `index : content \n`